### PR TITLE
Bundler update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.5.5
         environment:
+          BUNDLER_VERSION: 2.0.1
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
           BUNDLE_PATH: vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,17 @@ jobs:
     docker:
       - image: circleci/ruby:2.5.5
         environment:
-          BUNDLER_VERSION: 2.0.1
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
           BUNDLE_PATH: vendor/bundle
     steps:
       - checkout
+      - run:
+          name: Configure Bundler
+          command: |
+            echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler
       - run:
           name: Which bundler?
           command: bundle -v

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby "~> 2.5.3"
+ruby "~> 2.5.5"
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ PLATFORMS
 
 DEPENDENCIES
   boxt_ruby_style_guide!
-  bundler (~> 1.17, >= 1.17.3)
+  bundler (~> 2.0, >= 2.0.1)
   minitest (~> 5.11, >= 5.11.3)
   minitest-fail-fast (~> 0.1.0)
   minitest-macos-notification (~> 0.0.5)
@@ -90,7 +90,7 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.5.5p157
 
 BUNDLED WITH
    2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,4 +93,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/boxt_ruby_style_guide.gemspec
+++ b/boxt_ruby_style_guide.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "reek", "~> 5.3", ">= 5.3.0"
   spec.add_dependency "rubocop", "~> 0.67.2"
 
-  spec.add_development_dependency "bundler", "~> 1.17", ">= 1.17.3"
+  spec.add_development_dependency "bundler", "~> 2.0", ">= 2.0.1"
   spec.add_development_dependency "minitest", "~> 5.11", ">= 5.11.3"
   spec.add_development_dependency "minitest-fail-fast", "~> 0.1.0"
   spec.add_development_dependency "minitest-macos-notification", "~> 0.0.5"


### PR DESCRIPTION
Upgraded Bundler to 2.0.1 as Heroku now supports using it in deploys.