### PR TITLE
Disable Layout/AlignHash

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -9,11 +9,6 @@ AllCops:
     - "tmp/**/*"
     - "vendor/**/*"
 
-# To make Lorenzo happy
-Layout/AlignHash:
-  EnforcedColonStyle: table
-  EnforcedHashRocketStyle: table
-
 # Increase line length to 120
 Metrics/LineLength:
   Max: 120

--- a/default.yml
+++ b/default.yml
@@ -12,10 +12,12 @@ AllCops:
 # Increase line length to 120
 Metrics/LineLength:
   Max: 120
-
+  Exclude:
+    - "config/routes.rb"
 # Exclude class and method length for test
 Metrics/BlockLength:
   Exclude:
+    - "config/routes.rb"
     - "test/**/*"
 Metrics/ClassLength:
   Exclude:


### PR DESCRIPTION
### Why: 

- Amends to lines complying with this Cop affect surrounding lines. This makes for noisy diffs.
- Code is distorted by this rule, complying often means exaggerated alignment which conflicts with the (more important) line length rule.
- We're disabling this rule in recent engines PRs so we should make it a consistent rule.