### PR TITLE
Bumped rubocop and pending cops

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     boxt_ruby_style_guide (6.0.1)
-      rubocop (= 0.85.1)
+      rubocop (= 0.86.0)
       rubocop-faker (~> 1.0)
       rubocop-rails (~> 2.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.0.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -38,21 +38,21 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     os (1.1.0)
-    parallel (1.19.1)
-    parser (2.7.1.3)
-      ast (~> 2.4.0)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
-    rubocop (0.85.1)
+    rubocop (0.86.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.7)
       rexml
-      rubocop-ast (>= 0.0.3)
+      rubocop-ast (>= 0.0.3, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)

--- a/boxt_ruby_style_guide.gemspec
+++ b/boxt_ruby_style_guide.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
     "rails.yml"
   ]
 
-  spec.add_dependency "rubocop", "0.85.1" # locking rubocop so we can control the pending cops
+  spec.add_dependency "rubocop", "0.86.0" # locking rubocop so we can control the pending cops
   spec.add_dependency "rubocop-faker", "~> 1.0"
   spec.add_dependency "rubocop-rails", "~> 2.6"
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/pending.yml
+++ b/pending.yml
@@ -20,6 +20,8 @@ Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
   Enabled: true
+Style/RedundantFetchBlock:
+  Enabled: true
 Style/RedundantRegexpCharacterClass:
   Enabled: true
 Style/RedundantRegexpEscape:


### PR DESCRIPTION
Bumped `rubocop` to 0.86.0 and added the `Style/RedundantFetchBlock` pending cop.