### PR TITLE
[NO-JIRA] Remove docs for install_tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,6 @@ And then execute:
 bundle
 ```
 
-To make the lint rake tasks available to non Rails apps and gems, add the following to the project's `Rakefile`:
-
-```ruby
-require "boxt_ruby_style_guide"
-BoxtRubyStyleGuide.install_tasks
-```
-
 Rails apps should have access to the lint tasks by default.
 
 ## Usage


### PR DESCRIPTION
* Since the tasks were moved to the lib directory, the gemspec specifies
  lib as a path to load
* We no longer need to run the install_tasks method as the tasks are
  automatically loaded